### PR TITLE
Use sigil_S for moduledocs

### DIFF
--- a/lib/ecto_model/queryable.ex
+++ b/lib/ecto_model/queryable.ex
@@ -1,5 +1,5 @@
 defmodule EctoModel.Queryable do
-  @moduledoc """
+  @moduledoc ~S"""
   A behaviour for defining a `query/2` callback that can be used as an easy-to-use and fluent DSL for building
   Ecto queries in a consistent manner across different schemas.
 

--- a/lib/ecto_model/soft_delete.ex
+++ b/lib/ecto_model/soft_delete.ex
@@ -1,5 +1,5 @@
 defmodule EctoModel.SoftDelete do
-  @moduledoc """
+  @moduledoc ~S"""
   Module responsible for allowing your schemas to opt into soft delete functionality.
 
   ## Usage


### PR DESCRIPTION
This fixes an issue where `\\` is shown as a single `\` in the ExDoc output, because normal strings support escapes.