### PR TITLE
Move reading of environment variables to runtime.exs

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -3,8 +3,5 @@ import Config
 config :ecto_model, ecto_repos: [EctoModel.Repo], table_schema: "public"
 
 config :ecto_model, EctoModel.Repo,
-  database: System.fetch_env!("POSTGRES_DB"),
-  username: System.fetch_env!("POSTGRES_USER"),
-  password: System.fetch_env!("POSTGRES_PASSWORD"),
   pool: Ecto.Adapters.SQL.Sandbox,
   hostname: "localhost"

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -1,0 +1,6 @@
+import Config
+
+config :ecto_model, EctoModel.Repo,
+  database: System.fetch_env!("POSTGRES_DB"),
+  username: System.fetch_env!("POSTGRES_USER"),
+  password: System.fetch_env!("POSTGRES_PASSWORD")


### PR DESCRIPTION
This makes it so running e.g. `mix deps.get` doesn't require setting `POSTGRES_DB` and friends first.